### PR TITLE
WIP: Empty & Loading States

### DIFF
--- a/src/app/styles/app.css
+++ b/src/app/styles/app.css
@@ -317,6 +317,11 @@ body {
   margin-right: 0;
 }
 
+.empty-message {
+  padding: 1em;
+  text-align: center;
+}
+
 .bar.high {
   background: var(--ok);
 }

--- a/src/app/ui/hud/active-spells.js
+++ b/src/app/ui/hud/active-spells.js
@@ -36,10 +36,14 @@ module.exports = class ActiveSpells {
   }
 
   static list(spells) {
-    return m(
-      `ol.spells.scroll`,
-      spells.map(ActiveSpells.spell)
-    )
+    if (spells.length) {
+      return m(
+        `ol.spells.scroll`,
+        spells.map(ActiveSpells.spell)
+      )
+    } else {
+      return m(`div.empty-message`, "No active spells.")
+    }
   }
 
   static spells() {

--- a/src/app/ui/hud/injuries.js
+++ b/src/app/ui/hud/injuries.js
@@ -8,18 +8,23 @@ const Attrs = Lens.of("attrs")
 
 window.Injuries = module.exports = class Injuries {
   static list() {
-    return m(
-      "ol",
-      Injuries.injuries().map((injury) => {
-        return m(
-          `li.${injury.type}.severity-${injury.severity}`,
-          m(".value", [
-            m("span", injury.name + " / " + injury.type),
-            m("span", injury.severity),
-          ])
-        )
-      })
-    )
+    if (Injuries.injuries().length) {
+      return m(
+        "ol",
+        Injuries.injuries().map((injury) => {
+          return m(
+            `li.${injury.type}.severity-${injury.severity}`,
+            m(".value", [
+              m("span", injury.name + " / " + injury.type),
+              m("span", injury.severity),
+            ])
+          )
+        })
+      )
+    } else {
+      // TODO: Should have a loading state rather than saying there are no injuries at first when there might actually be injuries.
+      return m(`div.empty-message`, "No injuries.")
+    }
   }
 
   static injuries() {


### PR DESCRIPTION
Rather than a Panel showing nothing, it could say, for example, when there are no active spells or no injuries. 

Although there is a difference between empty and loading. At the moment, for injuries, it will say "No injuries." before it loads actual injuries. I haven't dug in enough to understand how data like this loads, but I imagine it's possible to have state on panels that indicate when it has the data it needs. 