### PR TITLE
feat: add config launcher.bin and :launch command

### DIFF
--- a/src/vimish/index.js
+++ b/src/vimish/index.js
@@ -47,10 +47,15 @@ exports.connect = exports.c = Command.of(
     if (!argv.port) {
       const running = await Autodetect.list()
 
-      const auto_detected =
-        running.find(
-          ({ name }) => ~name.indexOf(argv.name)
-        ) || {}
+      const auto_detected = running.find(
+        ({ name }) => ~name.indexOf(argv.name)
+      )
+
+      if (!auto_detected) {
+        throw new Error(
+          `could not find a session by the name ${argv.name}`
+        )
+      }
 
       Object.assign(argv, auto_detected)
     }
@@ -64,7 +69,8 @@ exports.connect = exports.c = Command.of(
     if (
       Session.find(
         (sess) =>
-          sess.port.toString() == argv.port.toString()
+          sess.port.toString() ==
+          (argv.port || "").toString()
       )
     ) {
       throw new Error(

--- a/src/vimish/index.js
+++ b/src/vimish/index.js
@@ -10,6 +10,8 @@ const Streams = require("../session/streams")
 const Macros = require("../macros")
 const CustomCSS = require("../storage/custom-css")
 
+const Launcher = require("./launcher")
+
 const redraw = (session) => {
   Bus.emit(Bus.events.FOCUS, session)
   Bus.emit(Bus.events.REDRAW)
@@ -318,3 +320,10 @@ exports["reload-skin"] = Command.of([], async () => {
     message: "successfully reloaded your skin",
   })
 })
+
+exports["launch"] = Command.of(
+  ["char", "port"],
+  async ({ char, port }) => {
+    return await Launcher.launch({ char, port })
+  }
+)

--- a/src/vimish/launcher.js
+++ b/src/vimish/launcher.js
@@ -1,8 +1,10 @@
 const path = require("path")
+const { format } = require("util")
 const LauncherSettings = require("../settings").of(
   "launcher"
 )
 const { spawn } = require("child_process")
+const Bus = require("../bus")
 
 exports.launch = async function ({ char, port }) {
   const bin = LauncherSettings.get("bin", false)
@@ -33,20 +35,27 @@ function spawn_launcher(bin, { char, port }) {
   })
 
   launcher.stdout.on("data", (data) => {
-    // todo : flash
-    console.log(`(%s):stdout: ${data}`, prepared_cmd)
+    Bus.emit(Bus.events.FLASH, {
+      kind: "info",
+      message: format("%s> %s", char, data),
+    })
   })
 
   launcher.stderr.on("data", (data) => {
-    // todo : flash
-    console.error(`(%s):stderr: ${data}`, prepared_cmd)
+    Bus.emit(Bus.events.FLASH, {
+      kind: "error",
+      message: format("%s> %s", char, data),
+    })
   })
 
   launcher.on("close", (code) => {
-    // todo : flash
-    console.log(
-      `(%s):child process exited with code ${code}`,
-      prepared_cmd
-    )
+    Bus.emit(Bus.events.FLASH, {
+      kind: "info",
+      message: format(
+        "%s> %s",
+        char,
+        `child process exited with code ${code}`
+      ),
+    })
   })
 }

--- a/src/vimish/launcher.js
+++ b/src/vimish/launcher.js
@@ -1,0 +1,52 @@
+const path = require("path")
+const LauncherSettings = require("../settings").of(
+  "launcher"
+)
+const { spawn } = require("child_process")
+
+exports.launch = async function ({ char, port }) {
+  const bin = LauncherSettings.get("bin", false)
+
+  if (typeof bin !== "string") {
+    throw new Error(
+      "config for launcher.bin must be set to an absolute path"
+    )
+  }
+
+  if (path.isAbsolute(bin)) {
+    spawn_launcher(bin, { char, port })
+  }
+}
+
+function spawn_launcher(bin, { char, port }) {
+  const with_char = bin.replace("{char}", char)
+
+  const prepared_cmd =
+    typeof port == "string"
+      ? with_char.replace("{port}", port)
+      : with_char
+
+  const [absolute_bin, ...argv] = prepared_cmd.split(" ")
+
+  const launcher = spawn(absolute_bin, argv, {
+    detached: true,
+  })
+
+  launcher.stdout.on("data", (data) => {
+    // todo : flash
+    console.log(`(%s):stdout: ${data}`, prepared_cmd)
+  })
+
+  launcher.stderr.on("data", (data) => {
+    // todo : flash
+    console.error(`(%s):stderr: ${data}`, prepared_cmd)
+  })
+
+  launcher.on("close", (code) => {
+    // todo : flash
+    console.log(
+      `(%s):child process exited with code ${code}`,
+      prepared_cmd
+    )
+  })
+}


### PR DESCRIPTION
allows for a `:launch <name> <port>` to be passed to a string in `config.json` at `launcher.bin`

this is my example how I am using it:
```json
"launcher": {
		"bin": "/home/benjamin/bin/cabal --login={char}"
	}
```