### PR TITLE
feat: death stream support

### DIFF
--- a/src/app/ui/cli.js
+++ b/src/app/ui/cli.js
@@ -129,7 +129,7 @@ module.exports = class CLI {
     const commandsModalClass = Lens.get(
       Session.current,
       "state._modals.commands",
-      []
+      false
     )
       ? "open"
       : ""

--- a/src/session/streams.js
+++ b/src/session/streams.js
@@ -12,6 +12,7 @@ module.exports = class Streams {
     logon: 1,
     logoff: 1,
     speech: 1,
+    death: 1,
   }
 
   static Settings = StreamsSettings

--- a/src/vimish/index.js
+++ b/src/vimish/index.js
@@ -322,7 +322,12 @@ exports.stream = exports.streams = Command.of(
     }
 
     Streams.Settings.set(`active.${stream}`, state)
-    Bus.emit(Bus.events.REDRAW)
+    Bus.emit(Bus.events.FLASH, {
+      kind: "ok",
+      message: `${stream} stream is now ${
+        state == 1 ? "on" : "off"
+      }`,
+    })
   }
 )
 


### PR DESCRIPTION
1. adds `:stream` command routing support for the `death` stream
2. refactors `:stream` command to use flash messaging for `Ok|Err` results
3. fixes an issue I missed in the modal PR

closes #34 