### PR TITLE
makes the window more draggable from the session panel and hands-wrap

### DIFF
--- a/src/app/styles/app.scss
+++ b/src/app/styles/app.scss
@@ -107,6 +107,15 @@ body {
   grid-column: 1 / 2;
   grid-row: 1 / 2;
 }
+
+#sessions,
+#hands-wrapper {
+  -webkit-app-region: drag;
+}
+#sessions ol li {
+  -webkit-app-region: no-drag;
+}
+
 #panels-left {
   grid-column: 2 / 3;
   grid-row: 1 / 2;

--- a/src/app/styles/compiled/app.css
+++ b/src/app/styles/compiled/app.css
@@ -105,14 +105,6 @@ body {
   grid-row: 1/2;
 }
 
-#sessions,
-#hands-wrapper {
-  -webkit-app-region: drag;
-}
-#sessions ol li {
-  -webkit-app-region: no-drag;
-}
-
 #panels-left {
   grid-column: 2/3;
   grid-row: 1/2;

--- a/src/app/styles/compiled/app.css
+++ b/src/app/styles/compiled/app.css
@@ -105,6 +105,14 @@ body {
   grid-row: 1/2;
 }
 
+#sessions,
+#hands-wrapper {
+  -webkit-app-region: drag;
+}
+#sessions ol li {
+  -webkit-app-region: no-drag;
+}
+
 #panels-left {
   grid-column: 2/3;
   grid-row: 1/2;


### PR DESCRIPTION
#35 Uses `-webkit-app-region: drag;` to allow the frameless main window to be dragged around from the sessions panel or the `hands-wrap`. 