### PR TITLE
fix: increase tick fps from 1/sec to 5/sec;

### DIFF
--- a/src/session/state.js
+++ b/src/session/state.js
@@ -178,6 +178,6 @@ module.exports = class SessionState {
         // Redraws don't happen on setInterval according to the docs
         // but it's an important time to redraw because a timer just started
         m.redraw()
-      }, 1000)
+      }, 1000 / 5) // 5 fps is more than enough for a text-based RPG
   }
 }


### PR DESCRIPTION
follow up for #32 and #20 

drawing 1 frame per second is too slow as there is a considerable margin of error.  by increasing it to 5 redraws per second we reduce that margin to at most 200ms