### PR TITLE
Adds a fallback in case a spell isn't found in spells.json

### DIFF
--- a/src/constants/spells/index.js
+++ b/src/constants/spells/index.js
@@ -16,5 +16,8 @@ module.exports = (spell) => {
       )
       break
   }
+  if (typeof spellDetail === "undefined") {
+    spellDetail = { name: spell.name }
+  }
   return spellDetail
 }


### PR DESCRIPTION
Master branch was throwing errors in game for me this morning...when `spellDetail` was left undefined because `spell.name` could not be found in spells.json. 

So...this just checks to see if `spellDetail` is defined, and if not reverts to using `spell.name`. 