### PR TITLE
fix: operate on innerHTML for text;

### DIFF
--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -60,6 +60,8 @@ function trimLineBreaks(string) {
     .replace(/(\r|\n)$/g, "")
 }
 
+exports.trimLineBreaks = trimLineBreaks
+
 function pre(string) {
   return `<pre>${string}</pre>`
 }

--- a/src/session/feed.js
+++ b/src/session/feed.js
@@ -204,9 +204,7 @@ module.exports = class Feed {
       return ele.remove()
     if (body.contains(ele)) return
     // clean up whitespace
-    if (ele.lastChild) {
-      ele.lastChild.textContent = ele.lastChild.textContent.trimEnd()
-    }
+    ele.innerHTML = Parser.trimLineBreaks(ele.innerHTML)
     await this.addLinks(ele)
     await this.addHilites(ele)
     this.append(ele)


### PR DESCRIPTION
It seems like some operations are batched from the server, so it's possible that  linebreaks can still happen, but this fixes the trivial cases for the most part.  closes #113 