### PR TITLE
Save Command History to Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Lich might also be `lich.rbw` on your setup. You can run multiple connections (f
 - [ ] Macros
 - [ ] Saved Logging
 - [ ] Download Public Themes
-- [ ] Clickable links
+- [x] Clickable links in game feed and ESP/LNet
 
 ## Meta Shortcuts
 

--- a/src/session/command-history.js
+++ b/src/session/command-history.js
@@ -1,4 +1,5 @@
 const LimitedList = require("../util/limited-list")
+const Storage = require("../storage")
 
 module.exports = class CommandHistory {
   static of() {
@@ -9,7 +10,20 @@ module.exports = class CommandHistory {
    */
   constructor() {
     this.index = 0
-    this.buffer = LimitedList.of([], { limit: 100 })
+
+    setTimeout(() => {
+      const name = document
+        .querySelector("#feed-wrapper")
+        .getAttribute("data-name")
+
+      const commandsFromStorage = Storage.get(
+        `commands-${name}`
+      )
+
+      this.buffer = LimitedList.of(commandsFromStorage, {
+        limit: 100,
+      })
+    }, 500)
   }
 
   add(command) {
@@ -17,6 +31,13 @@ module.exports = class CommandHistory {
       return (this.buffer.members[0] = command)
     }
     this.buffer.lpush(command)
+
+    // Save command list to Storage
+    const name = document
+      .querySelector("#feed-wrapper")
+      .getAttribute("data-name")
+
+    Storage.set(`commands-${name}`, this.buffer.members)
   }
 
   get last_index() {

--- a/src/session/command-history.js
+++ b/src/session/command-history.js
@@ -11,19 +11,13 @@ module.exports = class CommandHistory {
   constructor() {
     this.index = 0
 
-    setTimeout(() => {
-      const name = document
-        .querySelector("#feed-wrapper")
-        .getAttribute("data-name")
-
-      const commandsFromStorage = Storage.get(
-        `commands-${name}`
-      )
-
-      this.buffer = LimitedList.of(commandsFromStorage, {
+    // Load commands from storage
+    this.buffer = LimitedList.of(
+      Storage.get(`commandHistory`),
+      {
         limit: 100,
-      })
-    }, 500)
+      }
+    )
   }
 
   add(command) {
@@ -32,12 +26,8 @@ module.exports = class CommandHistory {
     }
     this.buffer.lpush(command)
 
-    // Save command list to Storage
-    const name = document
-      .querySelector("#feed-wrapper")
-      .getAttribute("data-name")
-
-    Storage.set(`commands-${name}`, this.buffer.members)
+    // Save commands into storage
+    Storage.set(`commandHistory`, this.buffer.members)
   }
 
   get last_index() {


### PR DESCRIPTION
For this: https://github.com/elanthia-online/illthorn/issues/13

Not working great now. The biggest problem (and this came up with Thoughts storage too) is that I'm not sure the best way to know the Character name (which I think is a good unique identifier for storage) at certain points in the code. So I resort to asking the DOM for it, which is bad enough as is, but in my first commit here, I even `setTimeout` for a bit because the DOM doesn't know it yet in time for the CLI `constructor`.

It does "work" though, except that it doesn't seem to be loading back in a command history on a per-session basis as it should, but instead loading in the same buffer for everyone.