### PR TITLE
Add fix command, add linting to Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ node_js:
 before_install:
   - sudo apt-get -y install fakeroot rpm
 
-script: yarn run test
+script:
+  - yarn lint
+  - yarn test
 
 before_deploy:
   - npx electron-forge publish --dry-run --platform=linux

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "start": "ENV=dev electron-forge start",
     "package": "electron-forge package",
     "make": "electron-forge make",
-    "lint": "eslint src",
+    "lint": "pretty-quick --check && eslint src",
+    "fix": "pretty-quick && eslint src --fix",
     "test": "echo \"No testing configured\"",
     "publish": "electron-forge publish"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged && yarn run lint"
+      "pre-commit": "pretty-quick --staged"
     }
   },
   "keywords": [],


### PR DESCRIPTION
This attempts to make lint and test stages run in Travis, removing the linting step from the pre-commit hook for speed. This also introduces a `fix` command which can be invoked as `yarn fix` that attempts to auto-fix whatever issues it can.