### PR TITLE
Resolve stance title on startup.

### DIFF
--- a/src/app/ui/hud/vitals.js
+++ b/src/app/ui/hud/vitals.js
@@ -26,6 +26,17 @@ module.exports = class Vitals {
     "pbarStance",
   ]
 
+  // List of stances in percentage order.
+  // Used for fixing the title on startup.
+  static STANCE_ORDER = [
+    "offensive",
+    "advance",
+    "forward",
+    "neutral",
+    "guarded",
+    "defensive",
+  ]
+
   static ID_TO_UI = {
     encumlevel: "encumbrance",
     mindState: "mind",
@@ -53,6 +64,13 @@ module.exports = class Vitals {
       const exp = (parsed.title.match(/(\d+)/) || [])[1]
       parsed.value = exp
       parsed.title = parsed.title.replace(exp, "").trim()
+    }
+
+    // At startup, the text may not be present. This fixes the title in that case.
+    if (parsed.title == "pbarStance") {
+      // Make sure that finer stance gradations don't produce incorrect indices.
+      const index = Math.floor(parsed.value / 20)
+      parsed.title = Vitals.STANCE_ORDER[index]
     }
 
     if (typeof parsed.value == "number") {


### PR DESCRIPTION
I'm also uncertain what `ID_TO_UI` does in this file, but that's irrelevant to this PR. This adds logic to handle determining the right text for stances on startup.