### PR TITLE
Document some functions, fix one bug, add unit tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ src/dist
 .sass-cache
 .webpack
 *.log
-
+yarn-error.log
+coverage

--- a/src/session/command-history.js
+++ b/src/session/command-history.js
@@ -1,6 +1,18 @@
 const LimitedList = require("../util/limited-list")
 const Storage = require("../storage")
 
+/**
+ * Safely wrap an index to a valid entry.
+ * @param {number} idx Index to be wrapped
+ * @param {number} length Length of array to wrap index for
+ */
+function wrap_index(idx, length) {
+  // Compute offset for modulus to operate on a positive value
+  let offset =
+    idx >= 0 ? 0 : Math.floor(1 + Math.abs(idx) / length) * length
+  return (idx + offset) % length
+}
+
 module.exports = class CommandHistory {
   static of() {
     return new CommandHistory()
@@ -23,9 +35,10 @@ module.exports = class CommandHistory {
    */
   add(command) {
     if (this.head().length == 0) {
-      return (this.buffer.members[0] = command)
+      this.buffer.members[0] = command
+    } else {
+      this.buffer.lpush(command)
     }
-    this.buffer.lpush(command)
 
     // Save commands into storage
     Storage.set(`commandHistory`, this.buffer.members)
@@ -38,32 +51,56 @@ module.exports = class CommandHistory {
     return Math.max(this.buffer.length - 1, 0)
   }
 
+  /**
+   * Step current index one step earlier in the history.
+   */
   forward() {
-    --this.index
-    if (this.index < 0) this.index = this.last_index
+    this.index = wrap_index(this.index - 1, this.length)
     //console.log("history:forward", this.index, this.read(), this.buffer.toJSON())
   }
 
+  /**
+   * Step current index one step deeper into the history.
+   */
   back() {
-    ++this.index
-    if (this.index > this.last_index) this.index = 0
+    this.index = wrap_index(this.index + 1, this.length)
     //console.log("history:back", this.index, this.read(), this.buffer.toJSON())
   }
 
+  /**
+   * Read specified entry in the history.
+   * @param {number} index of element to read
+   */
   read(index = this.index) {
     return this.buffer.members[index] || ""
   }
 
+  /**
+   * Update the history at the current index.
+   * @param {string} value New command to store at the current location.
+   */
   update(value) {
     this.buffer.members[this.index] = value
   }
 
+  /**
+   * Compute the list of history entries matching the specified text.
+   * @param {string} input Search string to compare against history.
+   * @returns Filtered subset of the history that starts with the specified string, and is longer than the query phrase.
+   */
   match(input) {
     return this.buffer.filter(
       (cmd) => cmd.startsWith(input) && cmd.length > input.length
     )
   }
 
+  /**
+   * Write current entry to specified element, and give it focus.
+   * @param {Element} input HTML element to store history entry
+   * @param {Object} obj Object with step flags.
+   * @param {boolean} obj.forward Flag indicating if index should move forward
+   * @param {boolean} obj.back Flag indicating if index should move back.
+   */
   write(input, { forward, back }) {
     input.value = this.read()
     if (forward) this.forward()
@@ -71,15 +108,22 @@ module.exports = class CommandHistory {
     input.focus()
   }
 
+  /**
+   * Reads the most recent entry in the history.
+   * @returns Most recent entry.
+   */
   head() {
     return this.read(0)
   }
 
+  /**
+   * Sets the current index to the specified value.
+   * @param {number} idx New index to set as current.
+   * @returns This instance.
+   */
   seek(idx) {
     // console.log("command:seek", idx)
-    this.index = idx
-    if (this.index < 0) this.index = this.last_index
-    if (this.index > this.last_index) this.index = 0
+    this.index = wrap_index(idx, this.length)
     return this
   }
 

--- a/src/util/limited-list.js
+++ b/src/util/limited-list.js
@@ -1,37 +1,77 @@
-module.exports = class LimitedList {
+/**
+ * List with a maximum number of entries.
+ */
+class LimitedList {
   static of(members = [], opts = {}) {
     return new LimitedList(members, opts)
   }
+
+  /**
+   * Constructor to create a new instance.
+   * @param {Array} members Initial array of entries.
+   * @param {object} opts Options to configure list.
+   * @param {number} opts.limit Max number of entries to support.
+   */
   constructor(members = [], opts = {}) {
     this.members = members
     this.limit = opts.limit || 100
   }
+
+  /**
+   * Access number of elements currently in list.
+   */
   get size() {
     return this.members.length
   }
+
+  /**
+   * Access number of elements currently in list.
+   */
   get length() {
     return this.size
   }
 
+  /**
+   * Produce JSON equivalent of this object.
+   */
   toJSON() {
     return this.members
   }
 
+  /**
+   * Return a filtered version of the array.
+   * @param  {...any} args Arguments to pass to filter.
+   * @returns Filtered version of the list.
+   */
   filter(...args) {
     return this.members.filter.apply(this.members, args)
   }
 
+  /**
+   * Add a set of items to the list.
+   * @param  {...any} items Items to add to the list
+   * @returns Return a reference to this list.
+   */
   lpush(...items) {
     this.members.unshift(...items)
     while (this.size > this.limit) this.rpop()
     return this
   }
 
+  /**
+   * Access first element in the list.
+   */
   head() {
-    this.members[0]
+    return this.members[0]
   }
 
+  /**
+   * Pop the final element from the list, and return it.
+   * @returns Last element in the array.
+   */
   rpop() {
     return this.members.pop()
   }
 }
+
+module.exports = LimitedList

--- a/test/limited-list.test.js
+++ b/test/limited-list.test.js
@@ -1,0 +1,49 @@
+"use strict"
+const { expect, test } = require("@jest/globals")
+const LimitedList = require("../src/util/limited-list")
+
+let startList = ["a", "b"]
+
+test("Construction", () => {
+  let list = LimitedList.of(startList, { limit: 3 })
+  expect(list.length).toBe(startList.length)
+  expect(list.members).toEqual(startList)
+
+  let secondList = new LimitedList()
+  expect(secondList.limit).toBe(100)
+
+  expect(LimitedList.of().members).toEqual([])
+})
+
+test("Size and length", () => {
+  let list = LimitedList.of(startList)
+  expect(list.size).toBe(list.length)
+})
+
+test("pushing elements to the list", () => {
+  let list = LimitedList.of(startList, { limit: 4 })
+  let updatedList = list.lpush("c", "d")
+  expect(updatedList.members).toEqual(["c", "d", "a", "b"])
+  list.lpush("d", "c")
+  expect(list.members).toEqual(["d", "c", "c", "d"])
+})
+
+test("filtering list", () => {
+  let testEntries = [1, 2, 3, 4]
+  let list = LimitedList.of(testEntries)
+  expect(
+    list.filter((cmd) => {
+      return cmd % 2 == 0
+    })
+  ).toEqual([2, 4])
+})
+
+test("head test", () => {
+  let headList = LimitedList.of(["a", "b"])
+  expect(headList.head()).toBe("a")
+})
+
+test("toJSON", () => {
+  let list = LimitedList.of(startList)
+  expect(list.toJSON()).toBe(startList)
+})


### PR DESCRIPTION
The main contribution here is fixing one bug in adding commands to the command history, and one bug in reading the head element of the limited list. Beyond that, this refactors how index wrapping works in the command history, which avoids if statements in favor of math operations. This also attempts to document the two classes. Finally, this expands unit tests to reach 100% coverage for both as reported by `yarn test --coverage`, and marks the the resulting `coverage` folder to be ignored by git.