### PR TITLE
Grab text or value to parse pbarstance correctly

### DIFF
--- a/src/app/ui/hud/vitals.js
+++ b/src/app/ui/hud/vitals.js
@@ -46,7 +46,7 @@ module.exports = class Vitals {
   }
 
   static parse(ele) {
-    const text = attr(ele, "text", attr(ele, "id"))
+    const text = attr(ele, "text", attr(ele, "value", attr(ele, "id")))
     const [_0, title, value, max] = text.match(Vitals.PATTERN) || []
     const parsed = {
       id: ele.className,


### PR DESCRIPTION
Minimal fix to fall back to the `value` field for `pbarstance`, which doesn't appear to have a `text` field like other progress bars at this point in the invocation.