### PR TITLE
Add support for moving directly via keyboard numpad

### DIFF
--- a/src/app/ui/cli.js
+++ b/src/app/ui/cli.js
@@ -76,8 +76,13 @@ module.exports = class CLI {
     cli.setSelectionRange(replacement - 1, replacement + "?".length)
   }
 
+  /**
+   * Handle any keypress relevant to the CLI.
+   * @param {event} e keypress causing the event
+   */
   static global_handlekeypress(e) {
     const cli = document.getElementById("cli")
+    // Do not process the event if a macro key is active.
     if (!cli || CLI.is_macro(e)) return
     if (e.key == "Enter") return CLI.on_enter(cli, cli.value)
     cli.focus()

--- a/src/app/ui/index.js
+++ b/src/app/ui/index.js
@@ -5,6 +5,7 @@ exports.Sessions = require("./sessions")
 exports.Hands = require("./hands")
 exports.HUD = require("./hud")
 exports.FlashMessage = require("./flash-message")
+exports.Numpad = require("./numpad")
 
 const InitLayout = require("./layout")
 InitLayout()

--- a/src/app/ui/numpad.js
+++ b/src/app/ui/numpad.js
@@ -1,0 +1,32 @@
+const CLI = require("./cli")
+
+module.exports = class Numpad {
+  /**
+   * Parse keypress events for numpad motion.
+   * @param {event} e keypress to evaluate
+   */
+  static handlekeypress(e) {
+    // Allow numpad to control movement.
+    const numpad_location = 3
+    // Map of keypress codes to directions.
+    const numpad_directions = {
+      Numpad1: "sw",
+      Numpad2: "s",
+      Numpad3: "se",
+      Numpad4: "w",
+      Numpad5: "out",
+      Numpad6: "e",
+      Numpad7: "nw",
+      Numpad8: "n",
+      Numpad9: "ne",
+      Numpad0: "up",
+      NumpadDecimal: "down",
+    }
+
+    // Move directly if input is from the numpad and matches a direction.
+    if (e.location == numpad_location && e.code in numpad_directions) {
+      e.preventDefault()
+      return CLI.game_cmd(numpad_directions[e.code])
+    }
+  }
+}

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -68,6 +68,7 @@ window.addEventListener("resize", function () {
 })
 
 document.addEventListener("keypress", UI.CLI.global_handlekeypress)
+document.addEventListener("keypress", UI.Numpad.handlekeypress)
 document.addEventListener("autocomplete/right", UI.CLI.autocomplete_right)
 
 document.addEventListener("click", (e) => {


### PR DESCRIPTION
This matches the feature found in a number of other front ends, allowing for faster keyboard based movement with the numpad.