### PR TITLE
Supprt numpad modifier modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     ]
   },
   "jest": {
-    "runner": "@jest-runner/electron/main",
-    "testEnvironment": "node"
+    "runner": "@jest-runner/electron/main"
   }
 }

--- a/src/app/ui/numpad.js
+++ b/src/app/ui/numpad.js
@@ -1,4 +1,5 @@
 const CLI = require("./cli")
+const parse_for_numpad = require("../../numpad/numpad")
 
 module.exports = class Numpad {
   /**
@@ -6,27 +7,12 @@ module.exports = class Numpad {
    * @param {event} e keypress to evaluate
    */
   static handlekeypress(e) {
-    // Allow numpad to control movement.
-    const numpad_location = 3
-    // Map of keypress codes to directions.
-    const numpad_directions = {
-      Numpad1: "sw",
-      Numpad2: "s",
-      Numpad3: "se",
-      Numpad4: "w",
-      Numpad5: "out",
-      Numpad6: "e",
-      Numpad7: "nw",
-      Numpad8: "n",
-      Numpad9: "ne",
-      Numpad0: "up",
-      NumpadDecimal: "down",
-    }
+    const command = parse_for_numpad(e)
 
-    // Move directly if input is from the numpad and matches a direction.
-    if (e.location == numpad_location && e.code in numpad_directions) {
-      e.preventDefault()
-      return CLI.game_cmd(numpad_directions[e.code])
+    if (command === "") {
+      return
     }
+    e.preventDefault()
+    return CLI.game_cmd(command)
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 const { app, BrowserWindow } = require("electron")
 const windowStateKeeper = require("electron-window-state")
 const contextMenu = require("electron-context-menu")
+const platform = require("src/util/platform")
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require("electron-squirrel-startup")) {
@@ -65,7 +66,7 @@ app.on("ready", createWindow)
 app.on("window-all-closed", () => {
   // On OS X it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== "darwin") {
+  if (!platform.isMac()) {
     app.quit()
   }
 })

--- a/src/numpad/numpad.js
+++ b/src/numpad/numpad.js
@@ -1,0 +1,47 @@
+const platform = require("../util/platform")
+/**
+ * Parse keypress events for numpad motion.
+ * @param {event} e keypress to evaluate
+ * @returns String representing mapped command, or an empty string.
+ */
+function parse_for_numpad(e) {
+  // Keypress isn't from the numpad with NumLock disabled, nothing to do.
+  if (
+    e.location != KeyboardEvent.DOM_KEY_LOCATION_NUMPAD ||
+    e.getModifierState("NumLock")
+  ) {
+    return ""
+  }
+  // Map of keypress codes to directions.
+  const numpad_directions = {
+    Numpad0: "up",
+    Numpad1: "sw",
+    Numpad2: "s",
+    Numpad3: "se",
+    Numpad4: "w",
+    Numpad5: "out",
+    Numpad6: "e",
+    Numpad7: "nw",
+    Numpad8: "n",
+    Numpad9: "ne",
+    NumpadDecimal: "down",
+  }
+
+  // Move directly if input is from the numpad and matches a direction.
+  if (!(e.code in numpad_directions)) {
+    return ""
+  }
+  // Support modifiers for sneaking or controlling a familiar.
+  const is_sneak = platform.isMac() ? e.metaKey : e.altKey
+  const is_familiar_command = e.ctrlKey
+  let command = ""
+  if (is_sneak) {
+    command += "sneak "
+  } else if (is_familiar_command) {
+    command += "tell familiar to go "
+  }
+  command += numpad_directions[e.code]
+  return command
+}
+
+module.exports = parse_for_numpad

--- a/src/util/platform.js
+++ b/src/util/platform.js
@@ -1,0 +1,56 @@
+/**
+ * Helper function to get platform, suitable for mocking in tests.
+ * @returns The platform process identifier.
+ */
+function getPlatform() {
+  return process.platform.process
+}
+
+/**
+ * Helper to check if the platform is Mac.
+ * @returns True if platform is Mac based.
+ */
+function isMac() {
+  console.log(getPlatform())
+  return getPlatform() === "darwin"
+}
+
+/**
+ * Helper to check if platform is Windows.
+ * @returns True if platform is Windows.
+ */
+function isWindows() {
+  return getPlatform() === "win32"
+}
+
+/**
+ * Helper to check if platform is Linux.
+ * @return True if platform is some flavor of Linux.
+ */
+function isLinux() {
+  const linux_names = new Set([
+    "aix",
+    "android",
+    "freebsd",
+    "linux",
+    "openbsd",
+    "sunprocess",
+  ])
+  return linux_names.has(getPlatform())
+}
+
+/**
+ * Helper to check if platform is POSIX-like.
+ * @returns True if platform is POSIX-like.
+ */
+function isPosix() {
+  return isMac() || isLinux()
+}
+
+module.exports = {
+  getPlatform,
+  isMac,
+  isWindows,
+  isLinux,
+  isPosix,
+}

--- a/test/command-history.test.js
+++ b/test/command-history.test.js
@@ -1,4 +1,3 @@
-"use strict"
 const { test, expect, beforeAll, afterAll } = require("@jest/globals")
 let Storage = require("../src/storage")
 

--- a/test/limited-list.test.js
+++ b/test/limited-list.test.js
@@ -1,4 +1,3 @@
-"use strict"
 const { expect, test } = require("@jest/globals")
 const LimitedList = require("../src/util/limited-list")
 

--- a/test/numpad.test.js
+++ b/test/numpad.test.js
@@ -1,0 +1,118 @@
+const { test, expect } = require("@jest/globals")
+
+jest.mock("../src/util/platform")
+const platform = require("../src/util/platform")
+platform.isMac.mockImplementation(() => true)
+
+const parse_for_numpad = require("../src/numpad/numpad")
+
+// Order is sorted by key, matching parse_for_numpad
+const direction_order = [
+  "up",
+  "sw",
+  "s",
+  "se",
+  "w",
+  "out",
+  "e",
+  "nw",
+  "n",
+  "ne",
+  "down",
+]
+const keypresses = []
+
+for (let i = 0; i < direction_order.length; ++i) {
+  const index_str = i != 10 ? i.toString() : "Decimal"
+  const key = i != 10 ? i.toString() : "."
+  keypresses.push({
+    key: key,
+    code: "Numpad" + index_str,
+    direction: direction_order[i],
+  })
+}
+
+test("Normal input", () => {
+  let keypress = new KeyboardEvent("keypress", { key: "1", code: "Key1" })
+  expect(parse_for_numpad(keypress)).toBeFalsy()
+  keypress = new KeyboardEvent("keypress", { key: "z", code: "KeyZ" })
+  expect(parse_for_numpad(keypress)).toBeFalsy()
+})
+
+test("Numpad inputs", () => {
+  keypresses.forEach((value, _0, _1) => {
+    const location = { location: KeyboardEvent.DOM_KEY_LOCATION_NUMPAD }
+    const options = Object.assign({}, value, location)
+    const keypress = new KeyboardEvent("keypress", options)
+    expect(parse_for_numpad(keypress)).toBe(value["direction"])
+  })
+})
+
+test("Numpad inputs with NumLock enabled", () => {
+  keypresses.forEach((value, _0, _1) => {
+    const location = { location: KeyboardEvent.DOM_KEY_LOCATION_NUMPAD }
+    const options = Object.assign({}, value, location)
+    const keypress = new KeyboardEvent("keypress", options)
+    keypress.getModifierState = jest.fn(() => true)
+    expect(parse_for_numpad(keypress)).toBeFalsy()
+  })
+})
+
+test("Numpad sneaking on Mac", () => {
+  platform.isMac.mockImplementation(() => true)
+  platform.isLinux.mockImplementation(() => false)
+  platform.isWindows.mockImplementation(() => false)
+  keypresses.forEach((value, _0, _1) => {
+    const location = {
+      location: KeyboardEvent.DOM_KEY_LOCATION_NUMPAD,
+      metaKey: true,
+    }
+    const options = Object.assign({}, value, location)
+    const keypress = new KeyboardEvent("keypress", options)
+    expect(parse_for_numpad(keypress)).toBe("sneak " + value["direction"])
+  })
+})
+
+test("Numpad sneaking on Windows", () => {
+  platform.isMac.mockImplementation(() => false)
+  platform.isLinux.mockImplementation(() => false)
+  platform.isWindows.mockImplementation(() => true)
+  keypresses.forEach((value, _0, _1) => {
+    const location = {
+      location: KeyboardEvent.DOM_KEY_LOCATION_NUMPAD,
+      altKey: true,
+    }
+    const options = Object.assign({}, value, location)
+    const keypress = new KeyboardEvent("keypress", options)
+    expect(parse_for_numpad(keypress)).toBe("sneak " + value["direction"])
+  })
+})
+
+test("Numpad sneaking on Linux", () => {
+  platform.isMac.mockImplementation(() => false)
+  platform.isLinux.mockImplementation(() => true)
+  platform.isWindows.mockImplementation(() => false)
+  keypresses.forEach((value, _0, _1) => {
+    const location = {
+      location: KeyboardEvent.DOM_KEY_LOCATION_NUMPAD,
+      altKey: true,
+    }
+    const options = Object.assign({}, value, location)
+    const keypress = new KeyboardEvent("keypress", options)
+    expect(parse_for_numpad(keypress)).toBe("sneak " + value["direction"])
+  })
+})
+
+test("Numpad familiar commands", () => {
+  keypresses.forEach((value, _0, _1) => {
+    const location = {
+      location: KeyboardEvent.DOM_KEY_LOCATION_NUMPAD,
+      ctrlKey: true,
+    }
+    const options = Object.assign({}, value, location)
+    const keypress = new KeyboardEvent("keypress", options)
+    expect(parse_for_numpad(keypress)).toBe(
+      "tell familiar to go " + value["direction"]
+    )
+  })
+})

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -1,4 +1,3 @@
-"use strict"
 const { test, expect } = require("@jest/globals")
 const time = require("../src/util/time")
 
@@ -15,13 +14,9 @@ test("90 minutes formats to include hours", () => {
 })
 
 test("1.5 days formats to include days as well", () => {
-  expect(time.format(60 * 60 * 24 * 1.5)).toBe(
-    "1d 12h 00m 00s"
-  )
+  expect(time.format(60 * 60 * 24 * 1.5)).toBe("1d 12h 00m 00s")
 })
 
 test("500 days doesn't produce years", () => {
-  expect(time.format(60 * 60 * 24 * 500)).toBe(
-    "500d 00m 00s"
-  )
+  expect(time.format(60 * 60 * 24 * 500)).toBe("500d 00m 00s")
 })


### PR DESCRIPTION
This adds sneaking and familiar movement with modifier keys, to match the behavior of other front ends (and as suggested in #181).

This also refactors the code to allow unit testing without having to fight mocking half the system. This requires introducing helper functions which can be mocked in order to test behavior on different platforms, but it works.