### PR TITLE
WIP: `new-window {character}` Command

### DIFF
--- a/src/vimish/commands/connect.js
+++ b/src/vimish/commands/connect.js
@@ -1,49 +1,6 @@
 const Command = require("../command")
-const Autodetect = require("../../autodetect")
-const { redraw } = require("../../util/redraw")
-const Session = require("../../session")
+const connectSession = require("../functions/connectSession.js")
 
-/**
- * connect to a session
- */
-exports.connect = exports.c = Command.of(
-  ["name", "port"],
-  async (argv) => {
-    // connect to all the sessions
-    if (!argv.port && !argv.name) {
-      return await Autodetect.connect_all()
-    }
-
-    // attempt to autodetect what port to connect to
-    if (!argv.port) {
-      const running = await Autodetect.list()
-
-      const auto_detected = running.find(
-        ({ name }) => ~name.indexOf(argv.name)
-      )
-
-      if (!auto_detected) {
-        throw new Error(
-          `could not find a session by the name ${argv.name}`
-        )
-      }
-
-      Object.assign(argv, auto_detected)
-    }
-
-    if (Session.has(argv.name)) {
-      throw new Error(`Session(name: ${argv.name}) already exists`)
-    }
-
-    if (
-      Session.find(
-        (sess) => sess.port.toString() == (argv.port || "").toString()
-      )
-    ) {
-      throw new Error(`Session(port: ${argv.port}) already exists`)
-    }
-
-    const session = await Session.of(argv)
-    redraw(session)
-  }
-)
+exports.connect = exports.c = Command.of(["name", "port"], (argv) => {
+  connectSession(argv)
+})

--- a/src/vimish/commands/new-window.js
+++ b/src/vimish/commands/new-window.js
@@ -1,29 +1,12 @@
 const electron = require("electron")
 const Command = require("../command")
 const windowStateKeeper = require("electron-window-state")
-const Session = require("../../session")
-
-// TODO: Pull in abstracted versions of these commands?
-// const quit = require("./quit")
-// const connect = require("./connect")
-
-// TODO: Should this stuff be extracted into a function to share with the Window creation stuff in `main.js`?
+const quitSession = require("../functions/quitSession.js")
+const connectSession = require("../functions/connectSession.js")
 
 exports["new-window"] = Command.of(["name"], async ({ name }) => {
   // Step 1) Quit old session
-  const candidates = Session.fuzzy_find(name)
-
-  if (candidates.length > 1) {
-    throw new Error(
-      `Ambigious match for name(${name}) found ${candidates.length} matches`
-    )
-  }
-
-  if (candidates.length == 0) {
-    throw new Error(`No matches found for name(${name})`)
-  }
-
-  candidates[0].destroy()
+  quitSession(name)
 
   // Step 2) Create new Window
   let newWindow
@@ -59,32 +42,12 @@ exports["new-window"] = Command.of(["name"], async ({ name }) => {
   newWindow.show()
 
   // and load the index.html of the app.
-  newWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY)
+  // can't open DevTools in new one.
+  newWindow.loadURL(
+    `${MAIN_WINDOW_WEBPACK_ENTRY}?character=${name}&port=???`
+  )
 
   // TODO: Figure out how to run a connect in the NEW Window
   // Step 3) Connect Session
-  // attempt to autodetect what port to connect to
-  // if (!argv.port) {
-  // let portAndName = {
-  //   name: name,
-  // }
-  // const running = await Autodetect.list()
-
-  // const auto_detected = running.find(
-  //   ({ name }) => ~name.indexOf(argv.name)
-  // )
-
-  // if (!auto_detected) {
-  //   throw new Error(`could not find a session by the name ${name}`)
-  // }
-
-  // Object.assign(portAndName, auto_detected)
-  // // }
-
-  // if (Session.has(name)) {
-  //   throw new Error(`Session(name: ${name}) already exists`)
-  // }
-
-  // const session = await Session.of(portAndName)
-  // redraw(session)
+  // connectSession(argv)
 })

--- a/src/vimish/commands/new-window.js
+++ b/src/vimish/commands/new-window.js
@@ -1,0 +1,90 @@
+const electron = require("electron")
+const Command = require("../command")
+const windowStateKeeper = require("electron-window-state")
+const Session = require("../../session")
+
+// TODO: Pull in abstracted versions of these commands?
+// const quit = require("./quit")
+// const connect = require("./connect")
+
+// TODO: Should this stuff be extracted into a function to share with the Window creation stuff in `main.js`?
+
+exports["new-window"] = Command.of(["name"], async ({ name }) => {
+  // Step 1) Quit old session
+  const candidates = Session.fuzzy_find(name)
+
+  if (candidates.length > 1) {
+    throw new Error(
+      `Ambigious match for name(${name}) found ${candidates.length} matches`
+    )
+  }
+
+  if (candidates.length == 0) {
+    throw new Error(`No matches found for name(${name})`)
+  }
+
+  candidates[0].destroy()
+
+  // Step 2) Create new Window
+  let newWindow
+
+  //define default window state
+  let newWindowState = windowStateKeeper({
+    defaultWidth: 1500,
+    defaultHeight: 1000,
+  })
+
+  // Create the browser window.
+  const BrowserWindow = electron.remote.BrowserWindow
+  newWindow = new BrowserWindow({
+    //set window state
+    x: newWindowState.x,
+    y: newWindowState.y,
+    width: newWindowState.width,
+    height: newWindowState.height,
+    show: false,
+    frame: false,
+    webPreferences: {
+      nodeIntegration: true,
+      nodeIntegrationInWorker: true,
+      webSecurity: false,
+      preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
+    },
+    titleBarStyle: "hidden",
+    icon: "/src/app/img/app-icon.png",
+  })
+
+  newWindowState.manage(newWindow)
+
+  newWindow.show()
+
+  // and load the index.html of the app.
+  newWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY)
+
+  // TODO: Figure out how to run a connect in the NEW Window
+  // Step 3) Connect Session
+  // attempt to autodetect what port to connect to
+  // if (!argv.port) {
+  // let portAndName = {
+  //   name: name,
+  // }
+  // const running = await Autodetect.list()
+
+  // const auto_detected = running.find(
+  //   ({ name }) => ~name.indexOf(argv.name)
+  // )
+
+  // if (!auto_detected) {
+  //   throw new Error(`could not find a session by the name ${name}`)
+  // }
+
+  // Object.assign(portAndName, auto_detected)
+  // // }
+
+  // if (Session.has(name)) {
+  //   throw new Error(`Session(name: ${name}) already exists`)
+  // }
+
+  // const session = await Session.of(portAndName)
+  // redraw(session)
+})

--- a/src/vimish/commands/quit.js
+++ b/src/vimish/commands/quit.js
@@ -1,23 +1,7 @@
 const Command = require("../command")
-const Lens = require("../../util/lens")
-const Session = require("../../session")
 
-exports.quit = exports.q = Command.of(["name"], async ({ name }) => {
-  if (!name) {
-    name = Lens.get(Session.focused(), "name")
-  }
+const quitSession = require("../functions/quitSession.js")
 
-  const candidates = Session.fuzzy_find(name)
-
-  if (candidates.length > 1) {
-    throw new Error(
-      `Ambigious match for name(${name}) found ${candidates.length} matches`
-    )
-  }
-
-  if (candidates.length == 0) {
-    throw new Error(`No matches found for name(${name})`)
-  }
-
-  candidates[0].destroy()
+exports.quit = Command.of(["name"], async ({ name }) => {
+  quitSession(name)
 })

--- a/src/vimish/functions/connectSession.js
+++ b/src/vimish/functions/connectSession.js
@@ -1,0 +1,40 @@
+const Session = require("../../session")
+const Autodetect = require("../../autodetect")
+const { redraw } = require("../../util/redraw")
+
+exports.connectSession = async (argv) => {
+  // connect to all the sessions
+  if (!argv.port && !argv.name) {
+    return await Autodetect.connect_all()
+  }
+
+  // attempt to autodetect what port to connect to
+  if (!argv.port) {
+    const running = await Autodetect.list()
+
+    const auto_detected = running.find(
+      ({ name }) => ~name.indexOf(argv.name)
+    )
+
+    if (!auto_detected) {
+      throw new Error(`could not find a session by the name ${argv.name}`)
+    }
+
+    Object.assign(argv, auto_detected)
+  }
+
+  if (Session.has(argv.name)) {
+    throw new Error(`Session(name: ${argv.name}) already exists`)
+  }
+
+  if (
+    Session.find(
+      (sess) => sess.port.toString() == (argv.port || "").toString()
+    )
+  ) {
+    throw new Error(`Session(port: ${argv.port}) already exists`)
+  }
+
+  const session = await Session.of(argv)
+  redraw(session)
+}

--- a/src/vimish/functions/quitSession.js
+++ b/src/vimish/functions/quitSession.js
@@ -1,0 +1,22 @@
+const Lens = require("../../util/lens")
+const Session = require("../../session")
+
+exports.quitSession = (name) => {
+  if (!name) {
+    name = Lens.get(Session.focused(), "name")
+  }
+
+  const candidates = Session.fuzzy_find(name)
+
+  if (candidates.length > 1) {
+    throw new Error(
+      `Ambigious match for name(${name}) found ${candidates.length} matches`
+    )
+  }
+
+  if (candidates.length == 0) {
+    throw new Error(`No matches found for name(${name})`)
+  }
+
+  candidates[0].destroy()
+}

--- a/src/vimish/index.js
+++ b/src/vimish/index.js
@@ -15,5 +15,6 @@ commands.set("sudo", require("./commands/sudo.js"))
 commands.set("swap", require("./commands/swap.js"))
 commands.set("theme", require("./commands/theme.js"))
 commands.set("ui", require("./commands/ui.js"))
+commands.set("new-window", require("./commands/new-window.js"))
 
 exports.commands = commands


### PR DESCRIPTION
The idea is I'd do:

```
:new-window Quivet
```

To break off a new window with that character. 

**It's not currently working.** I can `:quit` the current character, open a new window, but the attempt at connecting happens in the old window. It can be made to work if all you do is open the new window and manually `:quit` from the old window and manually `:connect` from the new window. 

There is a lot of re-used functionality here too, so refactoring would need to get done to abstract away stuff like quitting, building new windows, and connecting sessions. 